### PR TITLE
Fix scheduler bug running in foreground

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,6 @@ services:
     container_name: laravel-web
     environment:
       CONTAINER_ROLE: web
-      APP_LOG: syslog
       DB_HOST: mysql
       REDIS_HOST: redisdb
       BROADCAST_DRIVER: redis
@@ -23,7 +22,6 @@ services:
     container_name: laravel-scheduler
     environment:
       CONTAINER_ROLE: scheduler
-      APP_LOG: syslog
     links:
       - redisdb
       - mysql

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ elif [ "$role" = "scheduler" ]; then
     # Run the scheduler
     while [ true ]
     do
-      php artisan schedule:run --verbose --no-interaction
+      php artisan schedule:run --verbose --no-interaction &
       sleep 60
     done
 elif [ "$role" = "web" ]; then

--- a/src/app/Console/Kernel.php
+++ b/src/app/Console/Kernel.php
@@ -24,8 +24,8 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command('inspire')
-                 ->everyMinute();
+        $schedule->command('cron-test')
+                 ->withoutOverlapping();
     }
 
     /**

--- a/src/routes/console.php
+++ b/src/routes/console.php
@@ -16,3 +16,9 @@ use Illuminate\Foundation\Inspiring;
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->describe('Display an inspiring quote');
+
+Artisan::command('cron-test', function () {
+    app('log')->info('Starting cron test, sleeping for 80 seconds ' . \Carbon\Carbon::now()->toIso8601String());
+    sleep(80);
+    app('log')->info('Ending cron test' . \Carbon\Carbon::now()->toIso8601String());
+})->describe('Demonstrate an overlapping cron');


### PR DESCRIPTION
Fixes bug when scheduler runs in the foreground, it shouldn't stop the `sleep 60`.